### PR TITLE
Parse C+ String from MCDF File

### DIFF
--- a/.github/workflows/draft-release-with-zip.yml
+++ b/.github/workflows/draft-release-with-zip.yml
@@ -15,6 +15,17 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Install Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install tomli-w
+        run: python -m pip install tomli-w
+
+      - name: Get Python Dependencies Wheels
+        run: python get_dependencies.py
+
       - name: Get repo name and tag
         id: vars
         run: |

--- a/.github/workflows/draft-release-with-zip.yml
+++ b/.github/workflows/draft-release-with-zip.yml
@@ -37,7 +37,7 @@ jobs:
           set -e
           zipfile="${{ steps.vars.outputs.repo_name }}-${{ steps.vars.outputs.tag }}.zip"
           # Exclude repo.json, .gitignore, .git and .github
-          zip -r "$zipfile" . -x 'repo.json' '.gitignore' '.git/*' '.github/*'
+          zip -r "$zipfile" . -x 'repo.json' '.gitignore' '.git/*' '.github/*' 'get_dependencies.py'
           echo "ZIP file created: $zipfile"
 
       - name: Create draft release and upload ZIP

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -11,6 +11,7 @@ blender_version_min = "4.5.7"
 blender_version_max = "5.1.0"
 website = "https://github.com/ShinoMythmaker/Aetherblend"
 tags = ["Animation", "Rigging", "Import-Export", "3D-View"]
+dependencies = ["lz4"]
 
 [permissions]
 files = "Import files for most Aetherblends functions"

--- a/features/cplus/decoder.py
+++ b/features/cplus/decoder.py
@@ -226,20 +226,20 @@ def get_mcdf_cplus(path: str) -> str | None:
 
                 data.extend(chunk)
 
-        data_reader = BytesIO(data)
-        signature = data_reader.read(4).decode('utf-8')
+        with BytesIO(data) as data_reader:
+            signature = data_reader.read(4).decode('utf-8')
 
-        if signature != 'MCDF':
-            raise Exception(f'"MCDF" expected at the start of the file, got "{signature}" instead.')
+            if signature != 'MCDF':
+                raise Exception(f'"MCDF" expected at the start of the file, got "{signature}" instead.')
 
-        version = read_byte(data_reader)
+            version = read_byte(data_reader)
 
-        if version != 1:
-            raise Exception(f'Version {version} is unsupported.')
+            if version != 1:
+                raise Exception(f'Version {version} is unsupported.')
 
-        mcdf_json_size = read_int(data_reader)
-        mcdf_json = json.loads(data_reader.read(mcdf_json_size).decode('utf-8'))
-        return mcdf_json['CustomizePlusData']
+            mcdf_json_size = read_int(data_reader)
+            mcdf_json = json.loads(data_reader.read(mcdf_json_size).decode('utf-8'))
+            return mcdf_json['CustomizePlusData']
     except Exception as e:
         print("[AetherBlend] Failed to parse C+ string from MCDF file:", e)
         return None

--- a/features/cplus/decoder.py
+++ b/features/cplus/decoder.py
@@ -28,8 +28,20 @@ def get_bone_values(cplus_dict: dict, value_key: str) -> dict:
     bones = cplus_dict.get('Bones', {})
     new_bones = defaultdict(dict)
     for key in bones.keys():
+        if value_key not in bones[key]:
+            continue
+
         values = bones[key][value_key]
         if value_key in ['Translation', 'Rotation']:
+            if 'X' not in values:
+                values['X'] = 0.0
+            
+            if 'Y' not in values:
+                values['Y'] = 0.0
+
+            if 'Z' not in values:
+                values['Z'] = 0.0
+
             if values['X'] == values['Y'] == values['Z'] == 0.0:
                 continue
         new_bones[key] = values

--- a/features/cplus/decoder.py
+++ b/features/cplus/decoder.py
@@ -11,20 +11,15 @@ from bpy_extras.io_utils import axis_conversion
 from mathutils import Matrix
 from io import BufferedIOBase, BytesIO
 
-def translate_hash(the_hasherrrr: str) -> tuple[int | None, dict]:
+def translate_hash(the_hasherrrr: bytes) -> tuple[int, dict]:
     """
-    Decodes and decompresses a C+ string, returning the version and data dict.
+    Decompresses a C+ string, returning the version and data dict.
     """
-    try:
-        decoded = base64.b64decode(the_hasherrrr)
-        inflated = zlib.decompress(decoded, zlib.MAX_WBITS | 16)
-        version = inflated[0]
-        json_str = inflated.decode('utf-8')
-        data = json.loads(json_str[1:])
-        return version, data
-    except Exception as e:
-        print("[AetherBlend] Failed to parse C+ string:", e)
-        return None, {}
+    inflated = zlib.decompress(the_hasherrrr, zlib.MAX_WBITS | 16)
+    version = inflated[0]
+    json_str = inflated.decode('utf-8')
+    data = json.loads(json_str[1:])
+    return version, data
 
 def get_bone_values(cplus_dict: dict, value_key: str) -> dict:
     """

--- a/features/cplus/decoder.py
+++ b/features/cplus/decoder.py
@@ -1,4 +1,3 @@
-import base64
 import json
 import zlib
 import bpy

--- a/features/cplus/decoder.py
+++ b/features/cplus/decoder.py
@@ -4,10 +4,12 @@ import zlib
 import bpy
 import mathutils
 import math
+import lz4.block
 
 from collections import defaultdict
 from bpy_extras.io_utils import axis_conversion
 from mathutils import Matrix
+from io import BufferedIOBase, BytesIO
 
 def translate_hash(the_hasherrrr: str) -> tuple[int | None, dict]:
     """
@@ -129,3 +131,109 @@ def reapply_bone_orientation(
         bone.matrix = corrected_matrix
     
     bpy.ops.object.mode_set(mode=previous_mode)
+
+def read_size(reader: BufferedIOBase, size: int) -> int | None:
+    """
+    Reads the specified size of bytes, and returns the value as an integer.
+    Returns None if no more data can be read.
+    """
+    byte = reader.read(size)
+
+    if not byte:
+        return None
+
+    return int.from_bytes(byte, byteorder='little')
+
+def read_byte(reader: BufferedIOBase) -> int | None:
+    """
+    Reads a byte and returns the value as an integer.
+    Returns None if no more data can be read.
+    """
+    return read_size(reader, 1)
+
+def read_int(reader: BufferedIOBase) -> int | None:
+    """
+    Reads an integer and returns the value.
+    Returns None if no more data can be read.
+    """
+    return read_size(reader, 4)
+
+def read_leb128(reader: BufferedIOBase) -> int:
+    """
+    Reads an LEB128 compressed number and returns the value as an integer.
+    """
+    result = 0
+    shift = 0
+
+    while True:
+        byte = read_byte(reader)
+
+        if byte is None:
+            break
+
+        result |= (byte & 0x7F) << shift
+        shift += 7
+
+        if (byte & 0x80) == 0:
+            break
+
+    return result
+
+def get_chunk(file: BufferedIOBase) -> bytes | None:
+    """
+    Reads and processes a chunk, starting from where the file reader position is currently.
+    Returns None if no more data can be read.
+    """
+    magic = read_byte(file)
+
+    if magic is None:
+        return None
+
+    uncompressed_size = read_leb128(file)
+
+    # Uncompressed
+    if magic == 2:
+        return file.read(uncompressed_size)
+    # Compressed
+    elif magic == 3:
+        chunk_size = read_leb128(file)
+        chunk_data = file.read(chunk_size)
+        return lz4.block.decompress(chunk_data, uncompressed_size=uncompressed_size)
+    # Unknown
+    else:
+        raise Exception(f'Unknown Chunk Magic Value: {magic}')
+
+def get_mcdf_cplus(path: str) -> str | None:
+    """
+    Reads an MCDF file to retrieve it's C+ string.
+    Returns None if there was an error while reading the file.
+    """
+    try:
+        data = bytearray()
+
+        with open(path, 'rb') as file:
+            while True:
+                chunk = get_chunk(file)
+
+                if chunk is None:
+                    break
+
+                data.extend(chunk)
+
+        data_reader = BytesIO(data)
+        signature = data_reader.read(4).decode('utf-8')
+
+        if signature != 'MCDF':
+            raise Exception(f'"MCDF" expected at the start of the file, got "{signature}" instead.')
+
+        version = read_byte(data_reader)
+
+        if version != 1:
+            raise Exception(f'Version {version} is unsupported.')
+
+        mcdf_json_size = read_int(data_reader)
+        mcdf_json = json.loads(data_reader.read(mcdf_json_size).decode('utf-8'))
+        return mcdf_json['CustomizePlusData']
+    except Exception as e:
+        print("[AetherBlend] Failed to parse C+ string from MCDF file:", e)
+        return None

--- a/features/cplus/operators.py
+++ b/features/cplus/operators.py
@@ -263,9 +263,13 @@ class AETHER_OT_ParseFromMCDF(bpy.types.Operator):
         cplus_string = decoder.get_mcdf_cplus(self.filepath)
 
         if cplus_string is None:
-            self.report({'ERROR'}, "Invalid MCDF file.")
+            self.report({'ERROR'}, "[AetherBlend] Invalid MCDF file.")
             return {'CANCELLED'}
         
+        if not cplus_string:
+            self.report({'WARNING'}, "[AetherBlend] MCDF file read successfully, but it didn't contain any C+ data.")
+            return {'CANCELLED'}
+
         cplus.code = cplus_string
         self.report({'INFO'}, '[AetherBlend] C+ String read from MCDF file successfully.')
 

--- a/features/cplus/operators.py
+++ b/features/cplus/operators.py
@@ -1,4 +1,5 @@
 import bpy
+from bpy.props import StringProperty
 
 from ... import utils
 from . import decoder
@@ -216,8 +217,22 @@ class AETHER_OT_ParseFromMCDF(bpy.types.Operator):
     )
     bl_options = {'REGISTER', 'UNDO'}
 
+    filepath: StringProperty(subtype="FILE_PATH")  # type: ignore
+    filter_glob: StringProperty(default='*.mcdf', options={'HIDDEN'})  # type: ignore
+
+    def invoke(self, context, event):
+        context.window_manager.fileselect_add(self)
+        return {'RUNNING_MODAL'}
+
     def execute(self, context):
-        self.report({'INFO'}, "Test")
+        context.window.cursor_set('WAIT')
+
+        if not self.filepath or not self.filepath.lower().endswith('.mcdf'): 
+            self.report({'ERROR'}, "[AetherBlend] Invalid file format. Please select a .mcdf file.")
+            return {'CANCELLED'}
+
+        self.report({'INFO'}, self.filepath)
+        context.window.cursor_set('DEFAULT')
         return {'FINISHED'}
 
 def register():

--- a/features/cplus/operators.py
+++ b/features/cplus/operators.py
@@ -208,12 +208,26 @@ class AETHER_OT_RevertToBackup(bpy.types.Operator):
         self.report({'INFO'}, "Reverted CPlus changes to backup armature state.")
         return {'FINISHED'}
     
+class AETHER_OT_ParseFromMCDF(bpy.types.Operator):
+    bl_label = "Parse from MCDF file"
+    bl_idname = "aether.parse_cplus_from_mcdf"
+    bl_description = (
+        "Parses the C+ string from an MCDF file."
+    )
+    bl_options = {'REGISTER', 'UNDO'}
+
+    def execute(self, context):
+        self.report({'INFO'}, "Test")
+        return {'FINISHED'}
+
 def register():
     bpy.utils.register_class(AETHER_OT_QuickApplyCustomizePlus)
     bpy.utils.register_class(AETHER_OT_CreateBackupArmature)
     bpy.utils.register_class(AETHER_OT_RevertToBackup)
+    bpy.utils.register_class(AETHER_OT_ParseFromMCDF)
 
 def unregister():
     bpy.utils.unregister_class(AETHER_OT_QuickApplyCustomizePlus)
     bpy.utils.unregister_class(AETHER_OT_CreateBackupArmature)
     bpy.utils.unregister_class(AETHER_OT_RevertToBackup)
+    bpy.utils.unregister_class(AETHER_OT_ParseFromMCDF)

--- a/features/cplus/operators.py
+++ b/features/cplus/operators.py
@@ -227,11 +227,22 @@ class AETHER_OT_ParseFromMCDF(bpy.types.Operator):
     def execute(self, context):
         context.window.cursor_set('WAIT')
 
+        armature = context.active_object
+        cplus = getattr(armature, 'aether_cplus', None)
+
         if not self.filepath or not self.filepath.lower().endswith('.mcdf'): 
             self.report({'ERROR'}, "[AetherBlend] Invalid file format. Please select a .mcdf file.")
             return {'CANCELLED'}
+        
+        cplus_string = decoder.get_mcdf_cplus(self.filepath)
 
-        self.report({'INFO'}, self.filepath)
+        if cplus_string is None:
+            self.report({'ERROR'}, "Invalid MCDF file.")
+            return {'CANCELLED'}
+        
+        cplus.code = cplus_string
+        self.report({'INFO'}, '[AetherBlend] C+ String read from MCDF file successfully.')
+
         context.window.cursor_set('DEFAULT')
         return {'FINISHED'}
 

--- a/features/cplus/operators.py
+++ b/features/cplus/operators.py
@@ -29,8 +29,8 @@ class AETHER_OT_QuickApplyCustomizePlus(bpy.types.Operator):
         try:
             decoded = base64.b64decode(cplus_string)
 
-            data_reader = BytesIO(decoded)
-            signature = decoder.read_int(data_reader)
+            with BytesIO(decoded) as data_reader:
+                signature = decoder.read_int(data_reader)
 
             # Gzip Header
             if signature == 0x88B1F:

--- a/features/cplus/operators.py
+++ b/features/cplus/operators.py
@@ -1,5 +1,9 @@
 import bpy
+import base64
+import json
+
 from bpy.props import StringProperty
+from io import BytesIO
 
 from ... import utils
 from . import decoder
@@ -22,9 +26,31 @@ class AETHER_OT_QuickApplyCustomizePlus(bpy.types.Operator):
             self.report({'ERROR'}, "Please select a valid armature.")
             return {'CANCELLED'}
 
-        version, cplus_dict = decoder.translate_hash(cplus_string)
-        if not cplus_dict or version not in [4, 5]:
-            self.report({'ERROR'}, "Invalid or unsupported C+ string (must be version 4 or 5).")
+        try:
+            decoded = base64.b64decode(cplus_string)
+
+            data_reader = BytesIO(decoded)
+            signature = decoder.read_int(data_reader)
+
+            # Gzip Header
+            if signature == 0x88B1F:
+                version, cplus_dict = decoder.translate_hash(decoded)
+
+                if not cplus_dict:
+                    raise Exception('Invalid C+ String.')
+
+                if version not in [4, 5]:
+                    raise Exception('Unsupported C+ string (must be version 4 or 5).')
+            # MCDF C+ Strings are not compressed, and doesn't have a Version
+            else:
+                cplus_dict = json.loads(decoded)
+
+                # Unlike the regular C+ Strings, there's not that much to verify, so we just go with Bones
+                if 'Bones' not in cplus_dict:
+                    raise Exception('Invalid C+ String.')
+        except Exception as e:
+            print("[AetherBlend] Failed to Apply C+ String:", e)
+            self.report({'ERROR'}, "[AetherBlend] Invalid or Unsupported C+ String.")
             return {'CANCELLED'}
 
         scale_dict = decoder.get_bone_values(cplus_dict, 'Scaling')

--- a/features/cplus/panels.py
+++ b/features/cplus/panels.py
@@ -63,6 +63,11 @@ class AETHER_PT_CustomizePlus(bpy.types.Panel):
             col.separator()
 
             row = col.row(align=True)
+            row.operator("aether.parse_cplus_from_mcdf", text="Parse from MCDF file", icon = "IMPORT")
+
+            col.separator()
+
+            row = col.row(align=True)
             if aether_rig.rigified:
                 row = col.row(align=True)
                 row.operator("aether.clean_up_rig", text="Clean Up Rig", icon="BRUSH_DATA")

--- a/get_dependencies.py
+++ b/get_dependencies.py
@@ -1,0 +1,58 @@
+import json
+import os
+import tomllib
+import tomli_w
+import urllib.request
+
+MANIFEST_FILENAME = "blender_manifest.toml"
+WHEELS_DIR = './wheels'
+PYTHON_VERSIONS = ['cp311', 'cp313']
+
+def download_package_wheels(package_name: str) -> list:
+    filenames = []
+
+    pypi_json_url = urllib.request.urlopen(f'https://pypi.org/pypi/{package_name}/json')
+    pypi_json_data = pypi_json_url.read()
+    pypi_json = json.loads(pypi_json_data.decode('utf-8'))
+
+    releases = pypi_json['releases']
+    latest_release = next(reversed(releases))
+
+    for item in releases[latest_release]:
+        if (item['yanked'] == True or
+            item['packagetype'] != 'bdist_wheel' or
+            item['python_version'] not in PYTHON_VERSIONS):
+            continue
+
+        filename = item['filename']
+        path = f'{WHEELS_DIR}/{filename}'
+        urllib.request.urlretrieve(item['url'], path)
+        filenames.append(path)
+
+    return filenames
+
+def main():
+    if not os.path.isfile(MANIFEST_FILENAME):
+        print(f'[get_dependencies.py] Error: {MANIFEST_FILENAME} was not found.')
+        exit(1)
+
+    with open(MANIFEST_FILENAME, 'rb') as f:
+        manifest = tomllib.load(f)
+
+    manifest['wheels'] = []
+
+    os.makedirs(WHEELS_DIR, exist_ok=True)
+
+    for dependency in manifest['dependencies']:
+        dependency_wheels = download_package_wheels(dependency)
+
+        for wheel in dependency_wheels:
+            manifest['wheels'].append(wheel)
+    
+    del manifest['dependencies']
+
+    with open(MANIFEST_FILENAME, 'wb') as f:
+        tomli_w.dump(manifest, f)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adds a button in the C+ that allows to read the C+ String from an MCDF file.
- To be able to do this, this is now capable of reading MCDF files, and we only retrieve what's necessary.

MCDF C+ Strings are actually different than the regular ones, so these changes were made too:
- `AETHER_OT_QuickApplyCustomizePlus` identifies if it's a regular or an MCDF C+ String by checking if it starts with a Gzip header. Regular C+ Strings are compressed, while the MCDF ones are not.
- Version is only checked for regular C+ strings, but to not leave MCDF ones unverified, they look for the Bones key.
- Safety-nets added to `get_bone_values`, to prevent missing Key errors due to MCDF C+ Strings only having the needed ones.

To be able to read MCDF files, the `lz4` lib is required. To handle this, these additions were made:
- A new `dependencies` list was added to `blender_manifest.toml` to be able to be used in a script.
- To avoid having to include all the required Python wheels in the repository, and manually mantain them, a new script (`get_dependencies.py`) was added.
- This script reads the new list mentioned, and downloads all the wheels of the dependencies (_Note: it only goes for that dependency, it doesn't go through dependencies of dependencies_). After that, the `blender_manifest.toml` is rewritten to contain these downloaded wheels to be able to use in the extension.
- The `draft-release-with-zip.yml` workflow was edited to run this script before it creates the .zip, so everything is packed there.