### PR TITLE
Improve IVCS male genital rig behavior

### DIFF
--- a/features/rigging/templates/modules/genitals/ivcs_male.py
+++ b/features/rigging/templates/modules/genitals/ivcs_male.py
@@ -1,8 +1,22 @@
 from ......core.generators import ConnectBone, ExtensionBone
-from ......core.operations import ParentBoneOperation, RigifyTypeOperation, CollectionOperation
+from ......core.operations import ParentBoneOperation, RigifyTypeOperation, CollectionOperation, WidgetOperation
 from ......core.shared import PoseOperations, BoneGroup, RigModule, TransformLink
 from ......core import rigify
 from ......core.rigify.settings import UI_Collections, BoneCollection
+# IVCS color values as raw sRGB (0-1), matching pose_bone.color.custom expectations
+_IVCS_NORMAL = (0.8, 0.6745, 1.0)
+_IVCS_SELECT = (1.0, 1.0, 1.0)
+_IVCS_ACTIVE = (1.0, 0.9059, 0.7059)
+
+def _ivcs_widget(bone_name: str, scale_factor: float = 0.5) -> WidgetOperation:
+    return WidgetOperation(
+        bone_name=bone_name,
+        scale_factor=scale_factor,
+        color_set="CUSTOM",
+        custom_color_normal=_IVCS_NORMAL,
+        custom_color_select=_IVCS_SELECT,
+        custom_color_active=_IVCS_ACTIVE,
+    )
 
 GENITALS_M = BoneGroup(
     name="Male Genitals",
@@ -25,8 +39,8 @@ GENITALS_M = BoneGroup(
             is_connected=False,
             req_bones=["iv_ochinko_a", "iv_ochinko_b"],
             operations=[
-                RigifyTypeOperation(bone_name="Penis", rigify_type=rigify.types.skin_stretchy_chain()),
-                CollectionOperation(bone_name="Penis", collection_name="Genitals (Male)")
+                RigifyTypeOperation(time="Pre", bone_name="Penis", rigify_type=rigify.types.limbs_spline_tentacle(sik_stretch_control="MANUAL_STRETCH")),
+                CollectionOperation(time="Pre", bone_name="Penis", collection_name="AB-Meta"),
             ]
         ),
         ConnectBone(
@@ -37,7 +51,7 @@ GENITALS_M = BoneGroup(
             is_connected=True,
             req_bones=["iv_ochinko_b", "iv_ochinko_c"],
             operations=[
-                CollectionOperation(bone_name="Penis.001", collection_name="Genitals (Male)")
+                CollectionOperation(bone_name="Penis.001", collection_name="AB-Meta"),
             ]
         ),
         ConnectBone(
@@ -48,7 +62,7 @@ GENITALS_M = BoneGroup(
             is_connected=True,
             req_bones=["iv_ochinko_c", "iv_ochinko_d"],
             operations=[
-                CollectionOperation(bone_name="Penis.002", collection_name="Genitals (Male)")
+                CollectionOperation(bone_name="Penis.002", collection_name="AB-Meta"),
             ],
         ),
         ConnectBone(
@@ -59,7 +73,7 @@ GENITALS_M = BoneGroup(
             is_connected=True,
             req_bones=["iv_ochinko_d", "iv_ochinko_e"],
             operations=[
-                CollectionOperation(bone_name="Penis.003", collection_name="Genitals (Male)")
+                CollectionOperation(bone_name="Penis.003", collection_name="AB-Meta"),
             ]
         ),
         ConnectBone(
@@ -70,7 +84,7 @@ GENITALS_M = BoneGroup(
             is_connected=True,
             req_bones=["iv_ochinko_e", "iv_ochinko_f"],
             operations=[
-                CollectionOperation(bone_name="Penis.004", collection_name="Genitals (Male)")
+                CollectionOperation(bone_name="Penis.004", collection_name="AB-Meta"),
             ],
         ),
         ExtensionBone(
@@ -80,7 +94,7 @@ GENITALS_M = BoneGroup(
             is_connected=True,
             req_bones=["iv_ochinko_f"],
             operations=[
-                CollectionOperation(bone_name="Penis.005", collection_name="Genitals (Male)")
+                CollectionOperation(bone_name="Penis.005", collection_name="AB-Meta"),
             ]
         ),
         ExtensionBone(
@@ -119,5 +133,20 @@ def get_rig_module() -> RigModule:
         bone_groups=[GENITALS_M],
         ui_collections = UI_Collections([
             BoneCollection(name="Genitals (Male)", ui=True, color_set="IVCS", row_index=1, title="Genitals (Male)", visible=False),
-        ])
+            BoneCollection(name="AB-Meta", ui=False, color_set="IVCS", row_index=2, title="", visible=False),
+        ]),
+        operations=[
+            CollectionOperation(time="Post", bone_name="Penis-master", collection_name="Genitals (Male)"),
+            CollectionOperation(time="Post", bone_name="Penis-start01", collection_name="Genitals (Male)"),
+            CollectionOperation(time="Post", bone_name="Penis-mid01", collection_name="Genitals (Male)"),
+            CollectionOperation(time="Post", bone_name="Penis-end01", collection_name="Genitals (Male)"),
+            CollectionOperation(time="Post", bone_name="Penis-end", collection_name="Genitals (Male)"),
+            CollectionOperation(time="Post", bone_name="Penis-end-twist", collection_name="Genitals (Male)"),
+            _ivcs_widget("Penis-master"),
+            _ivcs_widget("Penis-start01"),
+            _ivcs_widget("Penis-mid01"),
+            _ivcs_widget("Penis-end01"),
+            _ivcs_widget("Penis-end"),
+            _ivcs_widget("Penis-end-twist"),
+        ]
     )

--- a/features/rigging/templates/modules/genitals/ivcs_male.py
+++ b/features/rigging/templates/modules/genitals/ivcs_male.py
@@ -3,10 +3,19 @@ from ......core.operations import ParentBoneOperation, RigifyTypeOperation, Coll
 from ......core.shared import PoseOperations, BoneGroup, RigModule, TransformLink
 from ......core import rigify
 from ......core.rigify.settings import UI_Collections, BoneCollection
-# IVCS color values as raw sRGB (0-1), matching pose_bone.color.custom expectations
-_IVCS_NORMAL = (0.8, 0.6745, 1.0)
-_IVCS_SELECT = (1.0, 1.0, 1.0)
-_IVCS_ACTIVE = (1.0, 0.9059, 0.7059)
+from ......features.rigging.templates.colorsets.cs_aetherblend import CS_AETHER_BLEND
+
+def _hex_to_srgb(hex_color: str) -> tuple:
+    """Converts a hex color string to raw sRGB (0-1) without linear conversion.
+    pose_bone.color.custom expects sRGB values, unlike rigify_colors which expects linear."""
+    hex_color = hex_color.lstrip('#')
+    lv = len(hex_color)
+    return tuple(int(hex_color[i:i + lv // 3], 16) / 255.0 for i in range(0, lv, lv // 3))
+
+_IVCS = CS_AETHER_BLEND["ivcs"]
+_IVCS_NORMAL = _hex_to_srgb(_IVCS.normal)
+_IVCS_SELECT = _hex_to_srgb(_IVCS.select)
+_IVCS_ACTIVE = _hex_to_srgb(_IVCS.active)
 
 def _ivcs_widget(bone_name: str, scale_factor: float = 0.5) -> WidgetOperation:
     return WidgetOperation(

--- a/features/rigging/templates/modules/genitals/ivcs_male.py
+++ b/features/rigging/templates/modules/genitals/ivcs_male.py
@@ -1,31 +1,8 @@
 from ......core.generators import ConnectBone, ExtensionBone
-from ......core.operations import ParentBoneOperation, RigifyTypeOperation, CollectionOperation, WidgetOperation
+from ......core.operations import ParentBoneOperation, RigifyTypeOperation, CollectionOperation
 from ......core.shared import PoseOperations, BoneGroup, RigModule, TransformLink
 from ......core import rigify
 from ......core.rigify.settings import UI_Collections, BoneCollection
-from ......features.rigging.templates.colorsets.cs_aetherblend import CS_AETHER_BLEND
-
-def _hex_to_srgb(hex_color: str) -> tuple:
-    """Converts a hex color string to raw sRGB (0-1) without linear conversion.
-    pose_bone.color.custom expects sRGB values, unlike rigify_colors which expects linear."""
-    hex_color = hex_color.lstrip('#')
-    lv = len(hex_color)
-    return tuple(int(hex_color[i:i + lv // 3], 16) / 255.0 for i in range(0, lv, lv // 3))
-
-_IVCS = CS_AETHER_BLEND["ivcs"]
-_IVCS_NORMAL = _hex_to_srgb(_IVCS.normal)
-_IVCS_SELECT = _hex_to_srgb(_IVCS.select)
-_IVCS_ACTIVE = _hex_to_srgb(_IVCS.active)
-
-def _ivcs_widget(bone_name: str, scale_factor: float = 0.5) -> WidgetOperation:
-    return WidgetOperation(
-        bone_name=bone_name,
-        scale_factor=scale_factor,
-        color_set="CUSTOM",
-        custom_color_normal=_IVCS_NORMAL,
-        custom_color_select=_IVCS_SELECT,
-        custom_color_active=_IVCS_ACTIVE,
-    )
 
 GENITALS_M = BoneGroup(
     name="Male Genitals",
@@ -48,8 +25,8 @@ GENITALS_M = BoneGroup(
             is_connected=False,
             req_bones=["iv_ochinko_a", "iv_ochinko_b"],
             operations=[
-                RigifyTypeOperation(time="Pre", bone_name="Penis", rigify_type=rigify.types.limbs_spline_tentacle(sik_stretch_control="MANUAL_STRETCH")),
-                CollectionOperation(time="Pre", bone_name="Penis", collection_name="AB-Meta"),
+                RigifyTypeOperation(bone_name="Penis", rigify_type=rigify.types.limbs_spline_tentacle(sik_stretch_control="MANUAL_STRETCH")),
+                CollectionOperation(bone_name="Penis", collection_name="Genitals (Male)")
             ]
         ),
         ConnectBone(
@@ -60,7 +37,7 @@ GENITALS_M = BoneGroup(
             is_connected=True,
             req_bones=["iv_ochinko_b", "iv_ochinko_c"],
             operations=[
-                CollectionOperation(bone_name="Penis.001", collection_name="AB-Meta"),
+                CollectionOperation(bone_name="Penis.001", collection_name="Genitals (Male)")
             ]
         ),
         ConnectBone(
@@ -71,7 +48,7 @@ GENITALS_M = BoneGroup(
             is_connected=True,
             req_bones=["iv_ochinko_c", "iv_ochinko_d"],
             operations=[
-                CollectionOperation(bone_name="Penis.002", collection_name="AB-Meta"),
+                CollectionOperation(bone_name="Penis.002", collection_name="Genitals (Male)")
             ],
         ),
         ConnectBone(
@@ -82,7 +59,7 @@ GENITALS_M = BoneGroup(
             is_connected=True,
             req_bones=["iv_ochinko_d", "iv_ochinko_e"],
             operations=[
-                CollectionOperation(bone_name="Penis.003", collection_name="AB-Meta"),
+                CollectionOperation(bone_name="Penis.003", collection_name="Genitals (Male)")
             ]
         ),
         ConnectBone(
@@ -93,7 +70,7 @@ GENITALS_M = BoneGroup(
             is_connected=True,
             req_bones=["iv_ochinko_e", "iv_ochinko_f"],
             operations=[
-                CollectionOperation(bone_name="Penis.004", collection_name="AB-Meta"),
+                CollectionOperation(bone_name="Penis.004", collection_name="Genitals (Male)")
             ],
         ),
         ExtensionBone(
@@ -103,7 +80,7 @@ GENITALS_M = BoneGroup(
             is_connected=True,
             req_bones=["iv_ochinko_f"],
             operations=[
-                CollectionOperation(bone_name="Penis.005", collection_name="AB-Meta"),
+                CollectionOperation(bone_name="Penis.005", collection_name="Genitals (Male)")
             ]
         ),
         ExtensionBone(
@@ -142,20 +119,5 @@ def get_rig_module() -> RigModule:
         bone_groups=[GENITALS_M],
         ui_collections = UI_Collections([
             BoneCollection(name="Genitals (Male)", ui=True, color_set="IVCS", row_index=1, title="Genitals (Male)", visible=False),
-            BoneCollection(name="AB-Meta", ui=False, color_set="IVCS", row_index=2, title="", visible=False),
-        ]),
-        operations=[
-            CollectionOperation(time="Post", bone_name="Penis-master", collection_name="Genitals (Male)"),
-            CollectionOperation(time="Post", bone_name="Penis-start01", collection_name="Genitals (Male)"),
-            CollectionOperation(time="Post", bone_name="Penis-mid01", collection_name="Genitals (Male)"),
-            CollectionOperation(time="Post", bone_name="Penis-end01", collection_name="Genitals (Male)"),
-            CollectionOperation(time="Post", bone_name="Penis-end", collection_name="Genitals (Male)"),
-            CollectionOperation(time="Post", bone_name="Penis-end-twist", collection_name="Genitals (Male)"),
-            _ivcs_widget("Penis-master"),
-            _ivcs_widget("Penis-start01"),
-            _ivcs_widget("Penis-mid01"),
-            _ivcs_widget("Penis-end01"),
-            _ivcs_widget("Penis-end"),
-            _ivcs_widget("Penis-end-twist"),
-        ]
+        ])
     )


### PR DESCRIPTION
The existing penis rig used `skin.stretchy_chain`, a type designed for facial skin deformation. In practice this caused the chain to stay rigid as a straight line and scale automatically to reach its target, making it difficult to pose naturally.

This PR switches the penis chain to `limbs.spline_tentacle` with `MANUAL_STRETCH`, which gives animators:
- A movable end target (Penis-end) to aim the chain
- A mid control (Penis-mid01) for proportional bending
- Stretch available as an explicit opt-in rather than automatic behavior

Testicle bones are unchanged.

Note: Penis through Penis.005 FK chain bones remain visible post-generation as non-poseable bones driven by the spline. Their default sphere widgets are the same size as the generated control bones, which creates some viewport clutter. Left out of scope intentionally at maintainer request.